### PR TITLE
Handle SIGPIPE on write XML

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,17 @@ fn main() {
     let stdout = io::stdout();
     let stdout = stdout.lock();
     let mut xml = EventWriter::new(stdout);
-    checkstyle.write_xml(&mut xml).expect("Error writing XML");
+    match checkstyle.write_xml(&mut xml) {
+        Ok(_) => {}
+        Err(xml::writer::Error::Io(e)) if e.kind() == io::ErrorKind::BrokenPipe => {
+            // ignore broken pipe
+            std::process::exit(141);
+        }
+        Err(e) => {
+            eprintln!("Error writing XML: {}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Rust ignore SIGPIPE by default: https://github.com/rust-lang/rust/issues/46016
- So, when run `clippy-reviewdog-filter` & `reviewdog` with pipe like below, sometimes `clippy-reviewdog-filter` panicked with `Broken pipe`
  - `cargo clippy --messsage-format json | clippy-reviewdog-filter | reviewdog ...`)
- This PR adds handle `std::io::ErrorKind::BrokenPipe` on write XML file to stdout to support these use case